### PR TITLE
Moving to Solidity 0.8.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ contract MySubordinate is ERC721Subordinate {
 }
 ```
 
+**Version 0.0.2 was not working with Solidity 0.8.17. Version 0.0.3 fixes the issue, but now it won't work with many previous version of Solidity. So, user ^0.8.17.** 
+
 ## Warnings
 
 The contract produces a lot of warnings during the compilation because there are part of the extended contract which are not reachable, views that could become pure but that would change the standard interface, etc. 
@@ -56,6 +58,9 @@ What makes the difference is the base token uri. Change that, and everything wil
 Feel free to make a PR to add your contracts.
 
 ## History
+
+**0.0.3**
+- make it work with Solidity 0.8.17, BREAKING previous support
 
 **0.0.2**
 - adding repo info to package.json

--- a/contracts/ERC721EnumerableSubordinate.sol
+++ b/contracts/ERC721EnumerableSubordinate.sol
@@ -30,25 +30,25 @@ contract ERC721Subordinate is ERC721, ERC721Enumerable {
 
   // core views
 
-  function balanceOf(address owner) public view override returns (uint256) {
+  function balanceOf(address owner) public view override(IERC721, ERC721) returns (uint256) {
     return _main.balanceOf(owner);
   }
 
-  function ownerOf(uint256 tokenId) public view override returns (address) {
+  function ownerOf(uint256 tokenId) public view override(IERC721, ERC721) returns (address) {
     return _main.ownerOf(tokenId);
   }
 
   // enumerable
 
-  function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
+  function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override(ERC721Enumerable) returns (uint256) {
     return _main.tokenOfOwnerByIndex(owner, index);
   }
 
-  function totalSupply() public view virtual override returns (uint256) {
+  function totalSupply() public view virtual override(ERC721Enumerable) returns (uint256) {
     return _main.totalSupply();
   }
 
-  function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
+  function tokenByIndex(uint256 index) public view virtual override(ERC721Enumerable) returns (uint256) {
     return _main.tokenByIndex(index);
   }
 
@@ -69,19 +69,19 @@ contract ERC721Subordinate is ERC721, ERC721Enumerable {
     return super.supportsInterface(interfaceId);
   }
 
-  function approve(address, uint256) public override(ERC721) {
+  function approve(address, uint256) public override(IERC721, ERC721) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function getApproved(uint256) public view override(ERC721) returns (address) {
+  function getApproved(uint256) public view override(IERC721, ERC721) returns (address) {
     return address(0);
   }
 
-  function setApprovalForAll(address, bool) public override(ERC721) {
+  function setApprovalForAll(address, bool) public override(IERC721, ERC721) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function isApprovedForAll(address, address) public view override(ERC721) returns (bool) {
+  function isApprovedForAll(address, address) public view override(IERC721, ERC721) returns (bool) {
     return false;
   }
 }

--- a/contracts/ERC721EnumerableSubordinateUpgradeable.sol
+++ b/contracts/ERC721EnumerableSubordinateUpgradeable.sol
@@ -42,25 +42,25 @@ abstract contract ERC721EnumerableSubordinateUpgradeable is
 
   // core views
 
-  function balanceOf(address owner) public view override returns (uint256) {
+  function balanceOf(address owner) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (uint256) {
     return _main.balanceOf(owner);
   }
 
-  function ownerOf(uint256 tokenId) public view override returns (address) {
+  function ownerOf(uint256 tokenId) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (address) {
     return _main.ownerOf(tokenId);
   }
 
   // enumerable
 
-  function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override returns (uint256) {
+  function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual override(ERC721EnumerableUpgradeable) returns (uint256) {
     return _main.tokenOfOwnerByIndex(owner, index);
   }
 
-  function totalSupply() public view virtual override returns (uint256) {
+  function totalSupply() public view virtual override(ERC721EnumerableUpgradeable) returns (uint256) {
     return _main.totalSupply();
   }
 
-  function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
+  function tokenByIndex(uint256 index) public view virtual override(ERC721EnumerableUpgradeable) returns (uint256) {
     return _main.tokenByIndex(index);
   }
 
@@ -86,19 +86,19 @@ abstract contract ERC721EnumerableSubordinateUpgradeable is
     return super.supportsInterface(interfaceId);
   }
 
-  function approve(address, uint256) public override(ERC721Upgradeable) {
+  function approve(address, uint256) public override(IERC721Upgradeable, ERC721Upgradeable) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function getApproved(uint256) public view override(ERC721Upgradeable) returns (address) {
+  function getApproved(uint256) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (address) {
     return address(0);
   }
 
-  function setApprovalForAll(address, bool) public override(ERC721Upgradeable) {
+  function setApprovalForAll(address, bool) public override(IERC721Upgradeable, ERC721Upgradeable) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function isApprovedForAll(address, address) public view override(ERC721Upgradeable) returns (bool) {
+  function isApprovedForAll(address, address) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (bool) {
     return false;
   }
 

--- a/contracts/ERC721Subordinate.sol
+++ b/contracts/ERC721Subordinate.sol
@@ -29,11 +29,11 @@ contract ERC721Subordinate is ERC721 {
 
   // core views
 
-  function balanceOf(address owner) public view override returns (uint256) {
+  function balanceOf(address owner) public view override(ERC721) returns (uint256) {
     return _main.balanceOf(owner);
   }
 
-  function ownerOf(uint256 tokenId) public view override returns (address) {
+  function ownerOf(uint256 tokenId) public view override(ERC721) returns (address) {
     return _main.ownerOf(tokenId);
   }
 

--- a/contracts/ERC721SubordinateUpgradeable.sol
+++ b/contracts/ERC721SubordinateUpgradeable.sol
@@ -42,11 +42,11 @@ abstract contract ERC721EnumerableSubordinateUpgradeable is
 
   // core views
 
-  function balanceOf(address owner) public view override returns (uint256) {
+  function balanceOf(address owner) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (uint256) {
     return _main.balanceOf(owner);
   }
 
-  function ownerOf(uint256 tokenId) public view override returns (address) {
+  function ownerOf(uint256 tokenId) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (address) {
     return _main.ownerOf(tokenId);
   }
 
@@ -72,19 +72,19 @@ abstract contract ERC721EnumerableSubordinateUpgradeable is
     return super.supportsInterface(interfaceId);
   }
 
-  function approve(address, uint256) public override(ERC721Upgradeable) {
+  function approve(address, uint256) public override(IERC721Upgradeable, ERC721Upgradeable) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function getApproved(uint256) public view override(ERC721Upgradeable) returns (address) {
+  function getApproved(uint256) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (address) {
     return address(0);
   }
 
-  function setApprovalForAll(address, bool) public override(ERC721Upgradeable) {
+  function setApprovalForAll(address, bool) public override(IERC721Upgradeable, ERC721Upgradeable) {
     revert SubordinateTokensAreNotTransferable();
   }
 
-  function isApprovedForAll(address, address) public view override(ERC721Upgradeable) returns (bool) {
+  function isApprovedForAll(address, address) public view override(IERC721Upgradeable, ERC721Upgradeable) returns (bool) {
     return false;
   }
 

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -19,7 +19,7 @@ task("accounts", "Prints the list of accounts", async () => {
  */
 module.exports = {
   solidity: {
-    version: "0.8.11",
+    version: "0.8.17",
     settings: {
       optimizer: {
         enabled: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721subordinate",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
This moves to Solidity 0.8.17 — which has breaking requirements with overriding functions.
It won't work with previous version, but since it is a new proposal, that should not be a big issue.