### PR TITLE
Fix missing initialization of the proxy in mock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ db
 .openzeppelin
 /test/fixtures/csv
 /export
+/flattened

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Feel free to make a PR to add your contracts.
 
 ## History
 
-**0.1.4**
+**0.1.4** — _version not published_
 - fix error in mock, not initializing UUPSUpgradeable
 
 **0.1.3**

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ Feel free to make a PR to add your contracts.
 
 ## History
 
+**0.1.4**
+- fix error in mock, not initializing UUPSUpgradeable
+
 **0.1.3**
 - remove unused dependencies (Context, ERC721Receiver)
 

--- a/contracts/mocks/MySubordinate.sol
+++ b/contracts/mocks/MySubordinate.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.9;
 import "../ERC721Subordinate.sol";
 
 contract MySubordinate is ERC721Subordinate {
-  constructor(address myToken) ERC721Subordinate("MyToken", "MTK", myToken) {}
+  constructor(address myToken) ERC721Subordinate("MY Subordinate", "mSUB", myToken) {}
 
   function getInterfaceId() public pure returns (bytes4) {
     return type(IERC721Subordinate).interfaceId;

--- a/contracts/mocks/MySubordinateEnumerableUpgradeable.sol
+++ b/contracts/mocks/MySubordinateEnumerableUpgradeable.sol
@@ -10,7 +10,7 @@ contract MySubordinateEnumerableUpgradeable is ERC721EnumerableSubordinateUpgrad
   constructor() initializer {}
 
   function initialize(address myTokenEnumerableUpgradeable) public initializer {
-    __ERC721EnumerableSubordinate_init("SuperToken", "SPT", myTokenEnumerableUpgradeable);
+    __ERC721EnumerableSubordinate_init("My Subordinate", "mSUBu", myTokenEnumerableUpgradeable);
     __UUPSUpgradeable_init();
   }
 

--- a/contracts/mocks/MySubordinateEnumerableUpgradeable.sol
+++ b/contracts/mocks/MySubordinateEnumerableUpgradeable.sol
@@ -11,6 +11,7 @@ contract MySubordinateEnumerableUpgradeable is ERC721EnumerableSubordinateUpgrad
 
   function initialize(address myTokenEnumerableUpgradeable) public initializer {
     __ERC721EnumerableSubordinate_init("SuperToken", "SPT", myTokenEnumerableUpgradeable);
+    __UUPSUpgradeable_init();
   }
 
   function _authorizeUpgrade(address newImplementation) internal virtual override {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721subordinate",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
In a mock it was missing a proper initialization of the UUPS proxy.
This version has not been published, because there are no changes in the production code.