### PR TITLE
Splitting badge and subordinate

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Feel free to make a PR to add your contracts.
 ## History
 
 **0.3.0**
-- adding an ERC721Badge which is extended by the subordinate
+- adding an ERC721Badge which is extended by the subordinate. BE CAREFUL, the change can break previous implementations
 
 **0.2.0**
 - remove the enumerable version because it is useless in the subordinates

--- a/README.md
+++ b/README.md
@@ -312,6 +312,9 @@ Feel free to make a PR to add your contracts.
 
 ## History
 
+**0.3.0**
+- adding an ERC721Badge which is extended by the subordinate
+
 **0.2.0**
 - remove the enumerable version because it is useless in the subordinates
 

--- a/contracts/ERC721Badge.sol
+++ b/contracts/ERC721Badge.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+import "./IERC721DefaultApprovable.sol";
+import "./IERC721DefaultLockable.sol";
+
+contract ERC721Badge is IERC721DefaultLockable, IERC721DefaultApprovable, ERC721{
+  constructor(string memory name, string memory symbol) ERC721(name, symbol) {
+    emit DefaultApprovable(false);
+    emit DefaultLocked(true);
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return
+    interfaceId == type(IERC721DefaultApprovable).interfaceId ||
+    interfaceId == type(IERC721DefaultLockable).interfaceId ||
+    super.supportsInterface(interfaceId);
+  }
+
+  function approvable(uint256) external view returns (bool) {
+    return false;
+  }
+
+  function locked(uint256) external view returns (bool) {
+    return true;
+  }
+
+  function approve(address, uint256) public virtual override {
+    revert("approvals not allowed");
+  }
+
+  function getApproved(uint256) public view virtual override returns (address) {
+    return address(0);
+  }
+
+  function setApprovalForAll(address, bool) public virtual override {
+    revert("approvals not allowed");
+  }
+
+
+  function isApprovedForAll(address, address) public view virtual override returns (bool) {
+    return false;
+  }
+
+  function transferFrom(
+    address,
+    address,
+    uint256
+  ) public virtual override {
+    revert("transfers not allowed");
+  }
+
+  function safeTransferFrom(
+    address,
+    address,
+    uint256,
+    bytes memory
+  ) public virtual override {
+    revert("transfers not allowed");
+  }
+}

--- a/contracts/ERC721BadgeUpgradeable.sol
+++ b/contracts/ERC721BadgeUpgradeable.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import "./IERC721DefaultApprovable.sol";
+import "./IERC721DefaultLockable.sol";
+
+contract ERC721BadgeUpgradeable is IERC721DefaultLockable, IERC721DefaultApprovable, Initializable, ERC721Upgradeable, OwnableUpgradeable{
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor() {
+    _disableInitializers();
+  }
+
+  function __ERC721Badge_init(string memory name_, string memory symbol_) internal initializer {
+    __ERC721_init(name_, symbol_);
+    __Ownable_init();
+    emit DefaultApprovable(false);
+    emit DefaultLocked(true);
+  }
+
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return
+    interfaceId == type(IERC721DefaultApprovable).interfaceId ||
+    interfaceId == type(IERC721DefaultLockable).interfaceId ||
+    super.supportsInterface(interfaceId);
+  }
+
+  function approvable(uint256) external view returns (bool) {
+    return false;
+  }
+
+  function locked(uint256) external view returns (bool) {
+    return true;
+  }
+
+  function approve(address, uint256) public virtual override {
+    revert("approvals not allowed");
+  }
+
+  function getApproved(uint256) public view virtual override returns (address) {
+    return address(0);
+  }
+
+  function setApprovalForAll(address, bool) public virtual override {
+    revert("approvals not allowed");
+  }
+
+
+  function isApprovedForAll(address, address) public view virtual override returns (bool) {
+    return false;
+  }
+
+  function transferFrom(
+    address,
+    address,
+    uint256
+  ) public virtual override {
+    revert("transfers not allowed");
+  }
+
+  function safeTransferFrom(
+    address,
+    address,
+    uint256,
+    bytes memory
+  ) public virtual override {
+    revert("transfers not allowed");
+  }
+}

--- a/contracts/ERC721Subordinate.sol
+++ b/contracts/ERC721Subordinate.sol
@@ -4,26 +4,24 @@ pragma solidity ^0.8.9;
 // Authors: Francesco Sullo <francesco@sullo.co>
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "@openzeppelin/contracts/utils/Strings.sol";
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 
 import "./IERC721Subordinate.sol";
-
-interface IERC721Extended is IERC165, IERC721, IERC721Metadata {}
+import "./ERC721Badge.sol";
 
 /**
  * @dev Implementation of IERC721Subordinate interface.
  * Strictly based on OpenZeppelin's implementation of https://eips.ethereum.org/EIPS/eip-721[ERC721]
  * in openzeppelin/contracts v4.8.0.
  */
-contract ERC721Subordinate is IERC721Subordinate, ERC165, IERC721, IERC721Metadata {
+contract ERC721Subordinate is IERC721Subordinate, ERC165, ERC721Badge {
   using Address for address;
   using Strings for uint256;
 
   // dominant token contract
-  IERC721Extended immutable private _dominant;
+  IERC721 immutable private _dominant;
 
   // Token name
   string private _name;
@@ -39,22 +37,18 @@ contract ERC721Subordinate is IERC721Subordinate, ERC165, IERC721, IERC721Metada
     string memory name_,
     string memory symbol_,
     address dominant_
-  ) {
-    _name = name_;
-    _symbol = symbol_;
+  ) ERC721Badge(name_, symbol_) {
     require(dominant_.isContract(), "ERC721Subordinate: not a contract");
-    _dominant = IERC721Extended(dominant_);
+    _dominant = IERC721(dominant_);
     require(_dominant.supportsInterface(type(IERC721).interfaceId), "ERC721Subordinate: dominant not IERC721");
   }
 
   /**
    * @dev See {IERC165-supportsInterface}.
    */
-  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, IERC165) returns (bool) {
+  function supportsInterface(bytes4 interfaceId) public view virtual override(ERC165, ERC721Badge) returns (bool) {
     return
       interfaceId == type(IERC721Subordinate).interfaceId ||
-      interfaceId == type(IERC721).interfaceId ||
-      interfaceId == type(IERC721Metadata).interfaceId ||
       super.supportsInterface(interfaceId);
   }
 
@@ -79,102 +73,4 @@ contract ERC721Subordinate is IERC721Subordinate, ERC165, IERC721, IERC721Metada
     return _dominant.ownerOf(tokenId);
   }
 
-  /**
-   * @dev See {IERC721Metadata-name}.
-   */
-  function name() public view virtual override returns (string memory) {
-    return _name;
-  }
-
-  /**
-   * @dev See {IERC721Metadata-symbol}.
-   */
-  function symbol() public view virtual override returns (string memory) {
-    return _symbol;
-  }
-
-  /**
-   * @dev See {IERC721Metadata-tokenURI}.
-   */
-  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-    try _dominant.tokenURI(tokenId) returns (string memory) {
-    } catch (
-      bytes memory /*lowLevelData*/
-    ) {
-      revert("ERC721Metadata: URI query for nonexistent token");
-    }
-    string memory baseURI = _baseURI();
-    return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
-  }
-
-  /**
-   * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
-   * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
-   * by default, can be overridden in child contracts.
-   */
-  function _baseURI() internal view virtual returns (string memory) {
-    return "";
-  }
-
-  /**
-   * @dev See {IERC721-approve}.
-   */
-  function approve(address, uint256) public virtual override {
-    revert("ERC721Subordinate: approvals not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-getApproved}.
-   */
-  function getApproved(uint256) public view virtual override returns (address) {
-    return address(0);
-  }
-
-  /**
-   * @dev See {IERC721-setApprovalForAll}.
-   */
-  function setApprovalForAll(address, bool) public virtual override {
-    revert("ERC721Subordinate: approvals not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-isApprovedForAll}.
-   */
-  function isApprovedForAll(address, address) public view virtual override returns (bool) {
-    return false;
-  }
-
-  /**
-   * @dev See {IERC721-transferFrom}.
-   */
-  function transferFrom(
-    address,
-    address,
-    uint256
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-safeTransferFrom}.
-   */
-  function safeTransferFrom(
-    address,
-    address,
-    uint256
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-safeTransferFrom}.
-   */
-  function safeTransferFrom(
-    address,
-    address,
-    uint256,
-    bytes memory
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
-  }
 }

--- a/contracts/ERC721SubordinateUpgradeable.sol
+++ b/contracts/ERC721SubordinateUpgradeable.sol
@@ -3,15 +3,12 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/IERC721MetadataUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/AddressUpgradeable.sol";
-import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 
 import "./IERC721SubordinateUpgradeable.sol";
-
-interface IERC721Extended is IERC165Upgradeable, IERC721Upgradeable, IERC721MetadataUpgradeable {}
+import "./ERC721BadgeUpgradeable.sol";
 
 /**
  * @dev Implementation of IERC721Subordinate interface based on the
@@ -21,16 +18,13 @@ interface IERC721Extended is IERC165Upgradeable, IERC721Upgradeable, IERC721Meta
  */
 contract ERC721SubordinateUpgradeable is
 IERC721SubordinateUpgradeable,
-Initializable,
-ERC165Upgradeable,
-IERC721Upgradeable,
-IERC721MetadataUpgradeable
+ERC721BadgeUpgradeable
 {
   using AddressUpgradeable for address;
   using StringsUpgradeable for uint256;
 
   // dominant token contract
-  IERC721Extended private _dominant;
+  IERC721Upgradeable private _dominant;
 
   // Token name
   string private _name;
@@ -44,11 +38,9 @@ IERC721MetadataUpgradeable
    */
   // solhint-disable
   function __ERC721Subordinate_init(string memory name_, string memory symbol_, address dominant_) internal initializer {
-    __ERC165_init_unchained();
-    _name = name_;
-    _symbol = symbol_;
+    __ERC721Badge_init(name_, symbol_);
     require(dominant_.isContract(), "ERC721Subordinate: not a contract");
-    _dominant = IERC721Extended(dominant_);
+    _dominant = IERC721Upgradeable(dominant_);
     require(_dominant.supportsInterface(type(IERC721Upgradeable).interfaceId), "ERC721Subordinate: dominant not IERC721");
   }
 
@@ -59,13 +51,10 @@ IERC721MetadataUpgradeable
   public
   view
   virtual
-  override(ERC165Upgradeable, IERC165Upgradeable)
+  override(ERC721BadgeUpgradeable)
   returns (bool)
   {
-    return
-    interfaceId == type(IERC721SubordinateUpgradeable).interfaceId ||
-    interfaceId == type(IERC721Upgradeable).interfaceId ||
-    interfaceId == type(IERC721MetadataUpgradeable).interfaceId ||
+    return interfaceId == type(IERC721SubordinateUpgradeable).interfaceId ||
     super.supportsInterface(interfaceId);
   }
 
@@ -88,105 +77,6 @@ IERC721MetadataUpgradeable
    */
   function ownerOf(uint256 tokenId) public view virtual override returns (address) {
     return _dominant.ownerOf(tokenId);
-  }
-
-  /**
-   * @dev See {IERC721Metadata-name}.
-   */
-  function name() public view virtual override returns (string memory) {
-    return _name;
-  }
-
-  /**
-   * @dev See {IERC721Metadata-symbol}.
-   */
-  function symbol() public view virtual override returns (string memory) {
-    return _symbol;
-  }
-
-  /**
-   * @dev See {IERC721Metadata-tokenURI}.
-   */
-  function tokenURI(uint256 tokenId) public view virtual override returns (string memory) {
-    try _dominant.tokenURI(tokenId) returns (string memory) {
-    } catch (
-      bytes memory /*lowLevelData*/
-    ) {
-      revert("ERC721Metadata: URI query for nonexistent token");
-    }
-    string memory baseURI = _baseURI();
-    return bytes(baseURI).length > 0 ? string(abi.encodePacked(baseURI, tokenId.toString())) : "";
-  }
-
-  /**
-   * @dev Base URI for computing {tokenURI}. If set, the resulting URI for each
-   * token will be the concatenation of the `baseURI` and the `tokenId`. Empty
-   * by default, can be overridden in child contracts.
-   */
-  function _baseURI() internal view virtual returns (string memory) {
-    return "";
-  }
-
-  /**
-   * @dev See {IERC721-approve}.
-   */
-  function approve(address, uint256) public virtual override {
-    revert("ERC721Subordinate: approvals not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-getApproved}.
-   */
-  function getApproved(uint256) public view virtual override returns (address) {
-    return address(0);
-  }
-
-  /**
-   * @dev See {IERC721-setApprovalForAll}.
-   */
-  function setApprovalForAll(address, bool) public virtual override {
-    revert("ERC721Subordinate: approvals not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-isApprovedForAll}.
-   */
-  function isApprovedForAll(address, address) public view virtual override returns (bool) {
-    return false;
-  }
-
-  /**
-   * @dev See {IERC721-transferFrom}.
-   */
-  function transferFrom(
-    address,
-    address,
-    uint256
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-safeTransferFrom}.
-   */
-  function safeTransferFrom(
-    address,
-    address,
-    uint256
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
-  }
-
-  /**
-   * @dev See {IERC721-safeTransferFrom}.
-   */
-  function safeTransferFrom(
-    address,
-    address,
-    uint256,
-    bytes memory
-  ) public virtual override {
-    revert("ERC721Subordinate: transfers not allowed");
   }
 
   uint256[50] private __gap;

--- a/contracts/IERC721DefaultApprovable.sol
+++ b/contracts/IERC721DefaultApprovable.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL3
+pragma solidity ^0.8.17;
+
+// Author: Francesco Sullo <francesco@sullo.co>
+
+// erc165 interfaceId 0xbfdf8f79
+interface IERC721DefaultApprovable {
+  // Must be emitted when the contract is deployed.
+  event DefaultApprovable(bool approvable);
+
+  // Must be emitted any time the status changes.
+  event Approvable(uint256 indexed tokenId, bool approvable);
+
+  // Returns true if the token is approvable.
+  // It should revert if the token does not exist.
+  function approvable(uint256 tokenId) external view returns (bool);
+
+  // A contract implementing this interface should not allow
+  // the approval for all. So, any actor validating this interface
+  // should assume that the tokens are not approvable for all.
+
+  // An extension of this interface may include info about the
+  // approval for all, but it should be considered as a separate
+  // feature, not as a replacement of this interface.
+}

--- a/contracts/IERC721DefaultLockable.sol
+++ b/contracts/IERC721DefaultLockable.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: CC0-1.0
+pragma solidity ^0.8.0;
+
+// erc165 interfaceId 0xb45a3c0e
+interface IERC721DefaultLockable {
+  // Must be emitted one time, when the contract is deployed,
+  // defining the default status of any token that will be minted
+  event DefaultLocked(bool locked);
+
+  // Must be emitted any time the status changes
+  event Locked(uint256 indexed tokenId, bool locked);
+
+  // Returns the status of the token.
+  // It should revert if the token does not exist.
+  function locked(uint256 tokenId) external view returns (bool);
+}

--- a/contracts/mocks/MyBadge.sol
+++ b/contracts/mocks/MyBadge.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.9;
+
+import "../ERC721Badge.sol";
+import "../ERC721BadgeUpgradeable.sol";
+
+contract MyBadge is ERC721Badge {
+  constructor() ERC721Badge("MY Badge", "mBDG") {}
+
+  function safeMint(address to, uint256 tokenId) public {
+    _safeMint(to, tokenId);
+  }
+
+}

--- a/contracts/mocks/MySubordinateUpgradeable.sol
+++ b/contracts/mocks/MySubordinateUpgradeable.sol
@@ -7,7 +7,9 @@ import "../ERC721SubordinateUpgradeable.sol";
 
 contract MySubordinateUpgradeable is ERC721SubordinateUpgradeable, UUPSUpgradeable {
   /// @custom:oz-upgrades-unsafe-allow constructor
-  constructor() initializer {}
+  constructor() {
+    _disableInitializers();
+  }
 
   function initialize(address myTokenEnumerableUpgradeable) public initializer {
     __ERC721Subordinate_init("My Subordinate", "mSUBu", myTokenEnumerableUpgradeable);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ndujalabs/erc721subordinate",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple approach to lock NFT in place w/out losing ownership",
   "publishConfig": {
     "access": "public"

--- a/test/Badge.test.js
+++ b/test/Badge.test.js
@@ -1,0 +1,41 @@
+const {expect} = require("chai");
+const { deployContractUpgradeable, deployContract, number} = require("./helpers");
+
+describe("Badge", function () {
+  let myBadge;
+
+  let owner, holder1, holder2, holder3, marketplace;
+
+  before(async function () {
+    [owner, holder1, holder2, holder3, marketplace] = await ethers.getSigners();
+  });
+
+  beforeEach(async function () {
+    myBadge = await deployContract("MyBadge");
+
+    await myBadge.safeMint(holder1.address, 1)
+    await myBadge.safeMint(holder2.address, 2)
+    await myBadge.safeMint(holder3.address, 3)
+
+    await myBadge.safeMint(holder1.address, 4)
+  });
+
+  it("should verify the properties of the badge", async function () {
+
+    expect(await myBadge.locked(1)).equal(true)
+    expect(await myBadge.approvable(1)).equal(false)
+
+    await expect(myBadge.connect(holder1).approve(marketplace.address, 1))
+        .revertedWith("approvals not allowed")
+
+    await expect(myBadge.connect(holder1).setApprovalForAll(marketplace.address, true))
+        .revertedWith("approvals not allowed")
+
+    await expect(myBadge.connect(holder1)["safeTransferFrom(address,address,uint256)"](holder1.address, holder2.address, 1))
+        .revertedWith("transfers not allowed")
+
+    await expect(myBadge.connect(holder1).transferFrom(holder1.address, holder2.address, 1))
+        .revertedWith("transfers not allowed")
+  });
+
+});


### PR DESCRIPTION
For Mobland, I need to split the subordinate from the badge. Then, I splitted it :-)
Basically, now a subordinate is a specific type of ERC721Badge, which implements IERC721DefaultApprovable and IERC721DefaultLocked